### PR TITLE
Changes from the IETF 96 hackathon

### DIFF
--- a/ClientProxy/ClientProxy.go
+++ b/ClientProxy/ClientProxy.go
@@ -193,7 +193,7 @@ func (this ClientProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 
 	postBytesReader := bytes.NewReader(request_bytes)
 
-	ServerInputurl = ServerInputurl + "/proxy_dns"
+	ServerInputurl = ServerInputurl + "/.well-known/dns-wireformat"
 
 	req, err := http.NewRequest("POST", ServerInputurl, postBytesReader) //need add random here in future
 	if err != nil {

--- a/ServerProxy/ServerProxy.go
+++ b/ServerProxy/ServerProxy.go
@@ -115,6 +115,15 @@ func (this Server) tryStaticHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (this Server) tryDNSoverHTTP(w http.ResponseWriter, r *http.Request) {
 	TransProString := r.Header.Get("Proxy-DNS-Transport")
+	if TransProString == "" {
+		TransProString = r.Header.Get("X-Proxy-DNS-Transport")
+	}
+	if TransProString == "" {
+		msg := fmt.Sprintf("No transport protocol specified")
+		_D("%s", msg)
+		http.Error(w, msg, 415)
+		return
+	}
 	if TransProString == "TCP" {
 		this.TransPro = TCPcode
 	} else if TransProString == "UDP" {
@@ -127,7 +136,7 @@ func (this Server) tryDNSoverHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	contentTypeStr := r.Header.Get("Content-Type")
 	if contentTypeStr != "application/octet-stream" {
-		msg := fmt.Sprintf("Unsupported content-type: %s", contentTypeStr)
+		msg := fmt.Sprintf("Unsupported content-type: '%s'", contentTypeStr)
 		_D("%s", msg)
 		http.Error(w, msg, 415)
 		return

--- a/ServerProxy/ServerProxy.go
+++ b/ServerProxy/ServerProxy.go
@@ -120,7 +120,7 @@ func (this Server) tryDNSoverHTTP(w http.ResponseWriter, r *http.Request) {
 	} else if TransProString == "UDP" {
 		this.TransPro = UDPcode
 	} else {
-		msg := fmt.Sprintf("Transport protocol not UDP or TCP: %s", this.TransPro)
+		msg := fmt.Sprintf("Transport protocol not UDP or TCP: %s", TransProString)
 		_D("%s", msg)
 		http.Error(w, msg, 415)
 		return

--- a/ServerProxy/ServerProxy.go
+++ b/ServerProxy/ServerProxy.go
@@ -68,8 +68,17 @@ func DoDNSquery(m dns.Msg, TransProString string, server []string, timeout time.
 	return dnsResponse, nil
 }
 
-//not sure how to make a server fail, error 501?
+// Process HTTP requests.
+// "dns-wireformat" requests get proxied, others get read out of our answer
+// directory.
 func (this Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/.well-known/dns-wireformat" {
+		this.tryDNSoverHTTP(w, r)
+        }
+}
+
+//not sure how to make a server fail, error 501?
+func (this Server) tryDNSoverHTTP(w http.ResponseWriter, r *http.Request) {
 	TransProString := r.Header.Get("Proxy-DNS-Transport")
 	if TransProString == "TCP" {
 		this.TransPro = TCPcode


### PR DESCRIPTION
This version improves some error messages, but the most important change is that it provides a way to act as a simple web server. Any file in the `html/` directory will be sent to a user who requests them, if the `/.well-known/dns-wireformat` URL is not used. 

It also looks for `X-Proxy-DNS-Transport` as well as `Proxy-DNS-Transport`, since browser-based JavaScript cannot issue a HTTP POST command with unknown header fields.
